### PR TITLE
Image download error handling

### DIFF
--- a/lib/imagga_auto_tag/tagged_image.rb
+++ b/lib/imagga_auto_tag/tagged_image.rb
@@ -5,15 +5,19 @@ module ImaggaAutoTag
     attr_reader :status, :tags
 
     def initialize(api_response)
+
       # The response from Imagga is now wrap in a results envelop
       #
       # ==== Result
+      # success:
       # { "results" => [{ "image" => "", "tags" => [{}, {}, {}] }] }
+      # failure:
+      # { "results" => [], "unsuccessful" => [{ "image" => url, "message" => msg }]}
       body = JSON.parse(api_response.body)
 
       @tags = []
 
-      body['results'][0]['tags'].each do |tag|
+      (body['results'][0] || {}).fetch('tags', []).each do |tag|
         @tags.push Tag.new(tag)
       end
 
@@ -27,7 +31,7 @@ module ImaggaAutoTag
     end
 
     def to_csv
-      @tags.collect { |t| t.name }.join(',')
+      @tags.collect(&:name).join(',')
     end
 
   end

--- a/spec/cassettes/image.yml
+++ b/spec/cassettes/image.yml
@@ -2,13 +2,13 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.imagga.com/draft/tags?api_key=acc_86d36eb78c04c30&url=http://static.ddmcdn.com/gif/landscape-photography-1.jpg
+    uri: https://api.imagga.com/v1/tagging?url=http://static.ddmcdn.com/gif/landscape-photography-1.jpg
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - Faraday v0.9.0
+      - Faraday v0.9.1
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -18,108 +18,72 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.6.0
-      Date:
-      - Wed, 10 Dec 2014 02:42:04 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '5920'
-      Connection:
-      - keep-alive
+      Access-Control-Allow-Headers:
+      - content-type, accept, cache-control, x-requested-with, authorization
+      Access-Control-Allow-Methods:
+      - GET
       Access-Control-Allow-Origin:
       - "*"
-      Access-Control-Allow-Methods:
-      - OPTIONS, PUT, GET, POST, DELETE
-      Access-Control-Allow-Headers:
-      - content-type, accept, cache-control, x-requested-with
       Access-Control-Max-Age:
       - '60'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 06 May 2015 19:44:17 GMT
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Set-Cookie:
+      - session=eyJyZXF1ZXN0X2lkIjp7IiBiIjoiTXpRM09EcGhZMk5mT0Raa016WmxZamM0WXpBMFl6TXcifX0.CCwAkQ.8QdcpHTw7p_0cKyNo2s5Sp-PE50;
+        HttpOnly; Path=/
+      Content-Length:
+      - '3394'
+      Connection:
+      - keep-alive
     body:
       encoding: UTF-8
-      string: "{\n    \"tags\": [\n        {\n            \"confidence\": 45.87292714129046,
-        \n            \"tag\": \"field\"\n        }, \n        {\n            \"confidence\":
-        45.019462630471075, \n            \"tag\": \"grass\"\n        }, \n        {\n
-        \           \"confidence\": 41.539616750533774, \n            \"tag\": \"meadow\"\n
-        \       }, \n        {\n            \"confidence\": 37.68175405091519, \n
-        \           \"tag\": \"landscape\"\n        }, \n        {\n            \"confidence\":
-        34.47865257334126, \n            \"tag\": \"summer\"\n        }, \n        {\n
-        \           \"confidence\": 33.133958517035, \n            \"tag\": \"sky\"\n
-        \       }, \n        {\n            \"confidence\": 29.98744024808808, \n
-        \           \"tag\": \"rural\"\n        }, \n        {\n            \"confidence\":
-        28.823619628995857, \n            \"tag\": \"countryside\"\n        }, \n
-        \       {\n            \"confidence\": 27.131082541347382, \n            \"tag\":
-        \"country\"\n        }, \n        {\n            \"confidence\": 27.093789187148097,
-        \n            \"tag\": \"spring\"\n        }, \n        {\n            \"confidence\":
-        25.714842645518626, \n            \"tag\": \"farm\"\n        }, \n        {\n
-        \           \"confidence\": 24.336827549986037, \n            \"tag\": \"horizon\"\n
-        \       }, \n        {\n            \"confidence\": 24.115280119433198, \n
-        \           \"tag\": \"clouds\"\n        }, \n        {\n            \"confidence\":
-        23.561707674279226, \n            \"tag\": \"sun\"\n        }, \n        {\n
-        \           \"confidence\": 23.556618136482914, \n            \"tag\": \"agriculture\"\n
-        \       }, \n        {\n            \"confidence\": 22.642037498437524, \n
-        \           \"tag\": \"cloud\"\n        }, \n        {\n            \"confidence\":
-        22.567807528953672, \n            \"tag\": \"sunny\"\n        }, \n        {\n
-        \           \"confidence\": 21.692051236071865, \n            \"tag\": \"plant\"\n
-        \       }, \n        {\n            \"confidence\": 21.469710723996684, \n
-        \           \"tag\": \"environment\"\n        }, \n        {\n            \"confidence\":
-        20.808006937712843, \n            \"tag\": \"outdoor\"\n        }, \n        {\n
-        \           \"confidence\": 20.273804774870438, \n            \"tag\": \"pasture\"\n
-        \       }, \n        {\n            \"confidence\": 19.97223888645286, \n
-        \           \"tag\": \"weather\"\n        }, \n        {\n            \"confidence\":
-        19.672755570551505, \n            \"tag\": \"season\"\n        }, \n        {\n
-        \           \"confidence\": 19.129671346370415, \n            \"tag\": \"lawn\"\n
-        \       }, \n        {\n            \"confidence\": 18.09129540318274, \n
-        \           \"tag\": \"outdoors\"\n        }, \n        {\n            \"confidence\":
-        17.82011861957261, \n            \"tag\": \"land\"\n        }, \n        {\n
-        \           \"confidence\": 17.53373669750844, \n            \"tag\": \"cloudscape\"\n
-        \       }, \n        {\n            \"confidence\": 17.227521342721275, \n
-        \           \"tag\": \"scenery\"\n        }, \n        {\n            \"confidence\":
-        17.0521923231383, \n            \"tag\": \"sunlight\"\n        }, \n        {\n
-        \           \"confidence\": 16.598898786080063, \n            \"tag\": \"outside\"\n
-        \       }, \n        {\n            \"confidence\": 16.490149573311943, \n
-        \           \"tag\": \"cloudy\"\n        }, \n        {\n            \"confidence\":
-        15.857062477693319, \n            \"tag\": \"clear\"\n        }, \n        {\n
-        \           \"confidence\": 15.829675488345195, \n            \"tag\": \"tree\"\n
-        \       }, \n        {\n            \"confidence\": 15.24591685171035, \n
-        \           \"tag\": \"plain\"\n        }, \n        {\n            \"confidence\":
-        15.071062582287361, \n            \"tag\": \"scene\"\n        }, \n        {\n
-        \           \"confidence\": 14.274802746575993, \n            \"tag\": \"day\"\n
-        \       }, \n        {\n            \"confidence\": 13.820782181417332, \n
-        \           \"tag\": \"hill\"\n        }, \n        {\n            \"confidence\":
-        13.37486025558128, \n            \"tag\": \"natural\"\n        }, \n        {\n
-        \           \"confidence\": 13.367081765784242, \n            \"tag\": \"farming\"\n
-        \       }, \n        {\n            \"confidence\": 12.898074060896516, \n
-        \           \"tag\": \"scenic\"\n        }, \n        {\n            \"confidence\":
-        10.999456006061584, \n            \"tag\": \"fields\"\n        }, \n        {\n
-        \           \"confidence\": 10.287484889012664, \n            \"tag\": \"grassland\"\n
-        \       }, \n        {\n            \"confidence\": 10.19599186203595, \n
-        \           \"tag\": \"farmland\"\n        }, \n        {\n            \"confidence\":
-        10.151697168209193, \n            \"tag\": \"fresh\"\n        }, \n        {\n
-        \           \"confidence\": 10.061411487391338, \n            \"tag\": \"park\"\n
-        \       }, \n        {\n            \"confidence\": 10.055026818532369, \n
-        \           \"tag\": \"flora\"\n        }, \n        {\n            \"confidence\":
-        9.471499129485952, \n            \"tag\": \"sunset\"\n        }, \n        {\n
-        \           \"confidence\": 9.435488194403247, \n            \"tag\": \"tranquil\"\n
-        \       }, \n        {\n            \"confidence\": 8.944498856145206, \n
-        \           \"tag\": \"travel\"\n        }, \n        {\n            \"confidence\":
-        8.836695582313878, \n            \"tag\": \"freedom\"\n        }, \n        {\n
-        \           \"confidence\": 8.68426390350368, \n            \"tag\": \"colorful\"\n
-        \       }, \n        {\n            \"confidence\": 8.358216968823195, \n
-        \           \"tag\": \"vibrant\"\n        }, \n        {\n            \"confidence\":
-        8.260337283211635, \n            \"tag\": \"idyllic\"\n        }, \n        {\n
-        \           \"confidence\": 8.182653073843216, \n            \"tag\": \"sunrise\"\n
-        \       }, \n        {\n            \"confidence\": 8.01481616674438, \n            \"tag\":
-        \"peaceful\"\n        }, \n        {\n            \"confidence\": 8.011175205099152,
-        \n            \"tag\": \"bright\"\n        }, \n        {\n            \"confidence\":
-        7.933190186126691, \n            \"tag\": \"color\"\n        }, \n        {\n
-        \           \"confidence\": 7.860003741597381, \n            \"tag\": \"yellow\"\n
-        \       }, \n        {\n            \"confidence\": 7.8105899950891775, \n
-        \           \"tag\": \"lea\"\n        }, \n        {\n            \"confidence\":
-        7.76446030144356, \n            \"tag\": \"heavens\"\n        }, \n        {\n
-        \           \"confidence\": 7.650482427445872, \n            \"tag\": \"vista\"\n
-        \       }\n    ]\n}\n"
+      string: '{"results": [{"image": "http://static.ddmcdn.com/gif/landscape-photography-1.jpg",
+        "tags": [{"confidence": 47.16994169669641, "tag": "grassland"}, {"confidence":
+        45.87292709198188, "tag": "field"}, {"confidence": 45.019462539740665, "tag":
+        "grass"}, {"confidence": 41.53961668314429, "tag": "meadow"}, {"confidence":
+        37.681753983890346, "tag": "landscape"}, {"confidence": 34.47865251401469,
+        "tag": "summer"}, {"confidence": 33.13395846563346, "tag": "sky"}, {"confidence":
+        29.98744017425953, "tag": "rural"}, {"confidence": 28.823619529162976, "tag":
+        "countryside"}, {"confidence": 27.13108249060661, "tag": "country"}, {"confidence":
+        27.093789115260403, "tag": "spring"}, {"confidence": 25.714842590319137, "tag":
+        "farm"}, {"confidence": 24.336827462837437, "tag": "horizon"}, {"confidence":
+        24.115280098473487, "tag": "clouds"}, {"confidence": 23.56170759210806, "tag":
+        "sun"}, {"confidence": 23.55661808909411, "tag": "agriculture"}, {"confidence":
+        22.64203743558242, "tag": "cloud"}, {"confidence": 22.567807470484027, "tag":
+        "sunny"}, {"confidence": 21.692051154694852, "tag": "plant"}, {"confidence":
+        21.4697106723974, "tag": "environment"}, {"confidence": 20.80800692342329,
+        "tag": "outdoor"}, {"confidence": 20.27380472909292, "tag": "pasture"}, {"confidence":
+        19.97223882234847, "tag": "weather"}, {"confidence": 19.672755524643385, "tag":
+        "season"}, {"confidence": 19.129671260375478, "tag": "lawn"}, {"confidence":
+        18.091295375332248, "tag": "outdoors"}, {"confidence": 17.820118550230625,
+        "tag": "land"}, {"confidence": 17.533736629067555, "tag": "cloudscape"}, {"confidence":
+        17.227521322226266, "tag": "scenery"}, {"confidence": 17.052192266625703,
+        "tag": "sunlight"}, {"confidence": 16.598898715047728, "tag": "outside"},
+        {"confidence": 16.490149489526726, "tag": "cloudy"}, {"confidence": 15.857062392231025,
+        "tag": "clear"}, {"confidence": 15.829675413246951, "tag": "tree"}, {"confidence":
+        15.245916761118902, "tag": "plain"}, {"confidence": 15.071062575498514, "tag":
+        "scene"}, {"confidence": 14.27480271119219, "tag": "day"}, {"confidence":
+        13.82078217457135, "tag": "hill"}, {"confidence": 13.374860237309415, "tag":
+        "natural"}, {"confidence": 13.36708172941655, "tag": "farming"}, {"confidence":
+        12.898074033486186, "tag": "scenic"}, {"confidence": 10.999455994858698, "tag":
+        "fields"}, {"confidence": 10.195991836252425, "tag": "farmland"}, {"confidence":
+        10.151697163068523, "tag": "fresh"}, {"confidence": 10.061411482100615, "tag":
+        "park"}, {"confidence": 10.055026806986385, "tag": "flora"}, {"confidence":
+        9.471499078203692, "tag": "sunset"}, {"confidence": 9.435488154330805, "tag":
+        "tranquil"}, {"confidence": 8.944498847707003, "tag": "travel"}, {"confidence":
+        8.836695580961415, "tag": "freedom"}, {"confidence": 8.68426388253624, "tag":
+        "colorful"}, {"confidence": 8.6, "tag": "eatage"}, {"confidence": 8.358216918457762,
+        "tag": "vibrant"}, {"confidence": 8.260337223076979, "tag": "idyllic"}, {"confidence":
+        8.182653016504954, "tag": "sunrise"}, {"confidence": 8.014816123314208, "tag":
+        "peaceful"}, {"confidence": 8.011175189956885, "tag": "bright"}, {"confidence":
+        7.933190150800882, "tag": "color"}, {"confidence": 7.860003745787088, "tag":
+        "yellow"}, {"confidence": 7.810589998365093, "tag": "lea"}, {"confidence":
+        7.793729720904508, "tag": "oak"}, {"confidence": 7.764460287180423, "tag":
+        "heavens"}, {"confidence": 7.650482355660379, "tag": "vista"}]}]}'
     http_version: 
-  recorded_at: Wed, 10 Dec 2014 02:42:04 GMT
+  recorded_at: Wed, 06 May 2015 19:43:07 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/no_download.yml
+++ b/spec/cassettes/no_download.yml
@@ -1,0 +1,47 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.imagga.com/v1/tagging?url=http://static.ddmcdn.com/gif/landscape-photography-1.jpg
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - content-type, accept, cache-control, x-requested-with, authorization
+      Access-Control-Allow-Methods:
+      - GET
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '60'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 06 May 2015 19:44:17 GMT
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Set-Cookie:
+      - session=eyJyZXF1ZXN0X2lkIjp7IiBiIjoiTXpRM09EcGhZMk5mT0Raa016WmxZamM0WXpBMFl6TXcifX0.CCwAkQ.8QdcpHTw7p_0cKyNo2s5Sp-PE50;
+        HttpOnly; Path=/
+      Content-Length:
+      - '184'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"results":[],"unsuccessful":[{"image":"https://unsplash.imgix.net/test-photo-21?q=75&fm=jpg&w=1080&fit=max&s=5d249291d47454d1c7bfac41318df561","message":"Could not download image."}]}'
+    http_version: 
+  recorded_at: Wed, 06 May 2015 19:43:07 GMT
+recorded_with: VCR 2.9.3

--- a/spec/imagga_auto_tag_spec.rb
+++ b/spec/imagga_auto_tag_spec.rb
@@ -18,7 +18,7 @@ describe "An Imagga Auto Tag API" do
 
   end
 
-  context "result" do
+  context "successful result" do
     
     before do
       VCR.use_cassette('image') do
@@ -54,6 +54,33 @@ describe "An Imagga Auto Tag API" do
 
     it "converts tags into a comma delimitted string" do
       expect(@results.to_csv).to be_an_instance_of(String)
+    end
+
+  end
+
+  context "could not download image" do
+    
+    before do
+      VCR.use_cassette('no_download') do
+        @client = ImaggaAutoTag::Client.new(ENV['IMAGGA_API_KEY'], ENV['IMAGGA_API_SECRET'])
+        @results = @client.fetch("http://static.ddmcdn.com/gif/landscape-photography-1.jpg")
+      end
+    end
+
+    it "returns a tagged image object" do
+      expect(@results).to be_an_instance_of(ImaggaAutoTag::TaggedImage)
+    end
+
+    it "has a status code" do
+      expect(@results.status).to be 200
+    end
+
+    it "does not have tags" do
+      expect(@results.tags).to be_empty
+    end
+
+    it "csv is empty string" do
+      expect(@results.to_csv).to eq ""
     end
 
   end


### PR DESCRIPTION
For now: at least prevent exceptions when Imagga returns a failure/error response. Probably want to add code to client in the future that checks that the request was successful before attempting to create the TaggedImage object.

As is, TaggedImage will still get created, just with an empty tag list.
