### PR TITLE
Release through travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+rvm:
+- 2.3.0
+language: ruby
+deploy:
+  provider: rubygems
+  api_key:
+    secure: P6IxTlvw3/UHpByeDkkun+APYvCzPgLhJWuPx+tg4LBRHD3dMAqLdeXufZmhOgSkL6NvTocTOZik04Ilw9/vI1IYKRT6alRpPDHdsx0MnrI9Rs6OXdkIpLga/s7MeuRSI3nIzR0ioDYjjiverdDweujtRetG7rxwCygu52A7OGI=
+  gem: imagga-auto-tag
+  on:
+    tags: true
+    repo: unsplash/imagga-auto-tag
+env:
+  global:
+    secure: IuQTRlcwjHgRty3TNQHdDNE9NSQA4OrNjS34eD9i1aTstRzhRyYyVOJvCGSo5T8dWClLnx4TTAC73xY+QGXaHNqce9ZzKBI8QCzGAp/h9Z++/Quv67Vtn0a+HhYSScWpGAp+Rz3sGFq9Q8Yu58KTDLnZF0SUvIURzCpBF+36R6k=

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,25 @@
+$:.unshift File.join(File.dirname(__FILE__), "lib")
+
 require 'rspec/core/rake_task'
+require 'imagga_auto_tag/version'
 
 RSpec::Core::RakeTask.new(:spec)
 
 task :default => :spec
+task :release do
+  puts "=> TravisCI handles the release. So this task will create a tag and push it"
+  `git pull --tags`
+
+  version = ImaggaAutoTag::VERSION
+  `git tag | grep #{version}`
+  already_exists = $?.exitstatus == 0
+  if already_exists
+    puts "-> v#{version} already exists, consider bumping"
+    exit(1)
+  end
+
+  `git tag v#{version}`
+  puts "=> Pushing tags"
+  `git push --tags`
+  puts "=> Version #{version} pushed!"
+end

--- a/imagga_auto_tag.gemspec
+++ b/imagga_auto_tag.gemspec
@@ -6,8 +6,8 @@ require 'imagga_auto_tag/version'
 Gem::Specification.new do |spec|
   spec.name          = 'imagga_auto_tag'
   spec.version       = ImaggaAutoTag::VERSION
-  spec.authors       = ['Luke Chesser']
-  spec.email         = ['luke@unsplash.com']
+  spec.authors       = ['Luke Chesser', 'Unsplash Team']
+  spec.email         = ['dev@unsplash.com']
   spec.summary       = 'Simple wrapper around the Imagga Auto Tagging API'
   spec.homepage      = 'https://github.com/crewlabs/imagga_auto_tag/'
   spec.license       = 'MIT'

--- a/lib/imagga_auto_tag/version.rb
+++ b/lib/imagga_auto_tag/version.rb
@@ -1,3 +1,3 @@
 module ImaggaAutoTag
-  VERSION = '0.2.1'.freeze
+  VERSION = '0.2.2'.freeze
 end


### PR DESCRIPTION
- Handles the release responsibility (and credentials) to Travis
- Version bump to match rubygems